### PR TITLE
[COST-3300] include infra and master nodes for each ocp yaml

### DIFF
--- a/static-files/ocp_on_aws_static_data.yaml
+++ b/static-files/ocp_on_aws_static_data.yaml
@@ -56,6 +56,7 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: aws_compute_2
+          node_labels: label_nodeclass:compute|label_node_role_kubernetes_io:infra
           cpu_cores: 2
           memory_gig: 8
           resource_id: 55555556
@@ -112,8 +113,8 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: aws_master
-          cpu_cores: 2
-          memory_gig: 8
+          cpu_cores: 4
+          memory_gig: 12
           resource_id: 55555558
           namespaces:
             kube-system:
@@ -136,3 +137,12 @@ generators:
                   mem_limit_gig: 4
                   pod_seconds: 3600
                   labels: label_environment:dev|label_app:master|label_version:master
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600

--- a/static-files/ocp_on_azure_static_data.yaml
+++ b/static-files/ocp_on_azure_static_data.yaml
@@ -56,6 +56,7 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: azure_compute_2
+          node_labels: label_nodeclass:compute|label_node_role_kubernetes_io:infra
           cpu_cores: 2
           memory_gig: 8
           resource_id: 99999996
@@ -112,8 +113,8 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: azure_master
-          cpu_cores: 2
-          memory_gig: 8
+          cpu_cores: 4
+          memory_gig: 12
           resource_id: 99999998
           namespaces:
             kube-system:
@@ -136,3 +137,12 @@ generators:
                   mem_limit_gig: 4
                   pod_seconds: 3600
                   labels: label_environment:Jupiter|label_app:Sombrero|label_version:Sombrero
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600

--- a/static-files/ocp_on_gcp_static_data.yaml
+++ b/static-files/ocp_on_gcp_static_data.yaml
@@ -72,7 +72,7 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: gcp_compute2
-          node_labels: label_nodeclass:compute
+          node_labels: label_nodeclass:compute|label_node_role_kubernetes_io:infra
           cpu_cores: 4
           memory_gig: 16
           namespaces:
@@ -144,8 +144,8 @@ generators:
         - node:
           node_name: gcp_master
           node_labels: label_nodeclass:master
-          cpu_cores: 2
-          memory_gig: 8
+          cpu_cores: 4
+          memory_gig: 12
           namespaces:
             kube-system:
               pods:
@@ -167,3 +167,12 @@ generators:
                   mem_limit_gig: 4
                   pod_seconds: 3600
                   labels: label_environment:ruby|label_app:summer|label_version:yellow
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600

--- a/static-files/ocp_on_premise.yaml
+++ b/static-files/ocp_on_premise.yaml
@@ -55,6 +55,7 @@ generators:
                     capacity_gig: 20
         - node:
           node_name: compute_2
+          node_labels: label_nodeclass:compute|label_node_role_kubernetes_io:infra
           cpu_cores: 4
           memory_gig: 16
           namespaces:
@@ -301,7 +302,7 @@ generators:
         - node:
           node_name: master_1
           cpu_cores: 4
-          memory_gig: 8
+          memory_gig: 12
           namespaces:
             kube-system:
               pods:
@@ -321,10 +322,19 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600
         - node:
           node_name: master_2
           cpu_cores: 4
-          memory_gig: 8
+          memory_gig: 12
           namespaces:
             kube-system:
               pods:
@@ -344,10 +354,19 @@ generators:
                   cpu_limit: 1
                   mem_limit_gig: 4
                   pod_seconds: 3600
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600
         - node:
           node_name: master_3
           cpu_cores: 4
-          memory_gig: 8
+          memory_gig: 12
           namespaces:
             kube-system:
               pods:
@@ -362,6 +381,15 @@ generators:
               pods:
                 - pod:
                   pod_name: pod_name18
+                  cpu_request: 1
+                  mem_request_gig: 2
+                  cpu_limit: 1
+                  mem_limit_gig: 4
+                  pod_seconds: 3600
+            openshift-kube-apiserver:
+              pods:
+                - pod:
+                  pod_name: pod_apiserver
                   cpu_request: 1
                   mem_request_gig: 2
                   cpu_limit: 1


### PR DESCRIPTION
Updates the OCP static YAMLS to include a node that will get classified as infra and a node that will get classified as master.