### PR TITLE
Use new Azure exceptions

### DIFF
--- a/nise-populator/sources/azure.py
+++ b/nise-populator/sources/azure.py
@@ -2,9 +2,9 @@ import logging
 import os
 
 from azure.core.exceptions import ResourceExistsError
+from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import ServiceResponseError
 from azure.storage.blob import BlobServiceClient
-from msrestazure.azure_exceptions import ClientException
-from msrestazure.azure_exceptions import CloudError
 from nise.report import azure_create_report
 
 from sources.source import Source
@@ -52,7 +52,7 @@ class Azure(Source):
             return True
         except (ResourceExistsError):
             return True
-        except (ClientException, CloudError) as err:
+        except (ServiceRequestError, ServiceResponseError) as err:
             LOG.info(f"Error: {err}")
             return False
 

--- a/nise-populator/sources/azure.py
+++ b/nise-populator/sources/azure.py
@@ -1,9 +1,8 @@
 import logging
 import os
 
+from azure.core.exceptions import HttpResponseError
 from azure.core.exceptions import ResourceExistsError
-from azure.core.exceptions import ServiceRequestError
-from azure.core.exceptions import ServiceResponseError
 from azure.storage.blob import BlobServiceClient
 from nise.report import azure_create_report
 
@@ -52,7 +51,7 @@ class Azure(Source):
             return True
         except (ResourceExistsError):
             return True
-        except (ServiceRequestError, ServiceResponseError) as err:
+        except (HttpResponseError, ValueError) as err:
             LOG.info(f"Error: {err}")
             return False
 


### PR DESCRIPTION
`msrestazure` is deprecated and was removed as dependency from `koku-nise`. That subsequently removed it as a dependency from this program as well, resulting in import errors when it is run.