### PR TITLE
[COST-3586] OCI make today start date

### DIFF
--- a/nise-populator/sources/oci.py
+++ b/nise-populator/sources/oci.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 
@@ -59,6 +60,7 @@ class OCI(Source):
         return True
 
     def generate(self):
+        self.start_date = datetime.datetime.today()
         options = {
             "start_date": self.start_date,
             "end_date": self.end_date,

--- a/static-files/oci_static_data.yml
+++ b/static-files/oci_static_data.yml
@@ -7,7 +7,7 @@ generators:
       consumed_quantity: 1219
       currency: USD
       compartment_name: richardprice
-      tenant_id: ocid1.tenancy.oc1..EfjkUPxyZSYLvd
+      tenant_id: ocid1.tenancy.oc1..vKlrzGToMPmkYGI
       subscription_id: 25906734
       tags:
         tags/free-form-tag: certainly
@@ -20,7 +20,7 @@ generators:
       consumed_quantity: 1089
       currency: USD
       compartment_name: richardprice
-      tenant_id: ocid1.tenancy.oc1..EfjkUPxyZSYLvd
+      tenant_id: ocid1.tenancy.oc1..vKlrzGToMPmkYGI
       subscription_id: 25906734
       tags:
         tags/new-tags.tarnished-tags: environmental
@@ -33,7 +33,7 @@ generators:
       consumed_quantity: 2005
       currency: USD
       compartment_name: richardprice
-      tenant_id: ocid1.tenancy.oc1..EfjkUPxyZSYLvd
+      tenant_id: ocid1.tenancy.oc1..vKlrzGToMPmkYGI
       subscription_id: 25906734
       tags:
         tags/free-form-tag: decision
@@ -45,7 +45,7 @@ generators:
       consumed_quantity: 2063
       currency: USD
       compartment_name: richardprice
-      tenant_id: ocid1.tenancy.oc1..EfjkUPxyZSYLvd
+      tenant_id: ocid1.tenancy.oc1..vKlrzGToMPmkYGI
       subscription_id: 25906734
       tags:
         tags/free-form-tag: at


### PR DESCRIPTION
This change ensures OCI uses `today` as start date and not the first day of the current month