### PR TITLE
Ensuring the generation of 24 hours of OCP data

### DIFF
--- a/nise-populator/sources/ocp.py
+++ b/nise-populator/sources/ocp.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from datetime import datetime
 from datetime import timedelta
 
 from nise.report import ocp_create_report
@@ -43,7 +42,7 @@ class OCP(Source):
 
     def generate(self):
         """Create data and upload it to the necessary location."""
-        self.start_date = datetime.today() - timedelta(days=1)
+        self.start_date = self.end_date - timedelta(days=1)
         options = {
             "start_date": self.start_date,
             "end_date": self.end_date,


### PR DESCRIPTION
This PR ensures that the OCP start_date is exactly 24 hours before the end_date, thus ensuring that a full day of OCP data is generated (previously the last 15 minutes were missed because the start_date was delayed by a few seconds).