### PR TITLE
update bucket name

### DIFF
--- a/static-files/default_sources.yaml
+++ b/static-files/default_sources.yaml
@@ -2,7 +2,7 @@
 sources:
     - aws_linked_ocp:
         type: AWS
-        bucket: nisepopulator
+        bucket: nise-populator
         report_prefix: cur
         report_name: awscost
         static-file: aws_static_data.yaml


### PR DESCRIPTION
This switches the underlined bucket name. You can't have the same bucket name across AWS accounts so in order to switch accounts we need to change the bucket name in use.