### PR TITLE
Update new azure account

### DIFF
--- a/static-files/default_sources.yaml
+++ b/static-files/default_sources.yaml
@@ -15,7 +15,7 @@ sources:
         storage_account: nisepopulatorstorage
         storage_container: cur
         report_prefix: cur
-        report_name: azurecost
+        report_name: nise-azurecost
         static-file: azure_static_data.yaml
     - ocp_linked_azure:
         type: OCP

--- a/static-files/default_sources.yaml
+++ b/static-files/default_sources.yaml
@@ -12,7 +12,7 @@ sources:
         static-file: ocp_on_aws_static_data.yaml
     - azure_linked_ocp:
         type: Azure
-        storage_account: nisepopulator
+        storage_account: newnisepopulator
         storage_container: cur
         report_prefix: cur
         report_name: azurecost

--- a/static-files/default_sources.yaml
+++ b/static-files/default_sources.yaml
@@ -12,7 +12,7 @@ sources:
         static-file: ocp_on_aws_static_data.yaml
     - azure_linked_ocp:
         type: Azure
-        storage_account: newnisepopulator
+        storage_account: nisepopulatorstorage
         storage_container: cur
         report_prefix: cur
         report_name: azurecost


### PR DESCRIPTION
Azure requires unique storage account names across all tenants. In order to change to the new dev account we need to create a new storage account and thus update the name here.

## Summary by Sourcery

Enhancements:
- Change storage_account from 'nisepopulator' to 'nisepopulatorstorage' for the Azure source entry