### PR TITLE
update aws bucket

### DIFF
--- a/static-files/default_sources.yaml
+++ b/static-files/default_sources.yaml
@@ -2,7 +2,7 @@
 sources:
     - aws_linked_ocp:
         type: AWS
-        bucket: nise-populator
+        bucket: nisepopulator
         report_prefix: cur
         report_name: awscost
         static-file: aws_static_data.yaml


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct AWS bucket name in default_sources.yaml from 'nise-populator' to 'nisepopulator'