### PR TITLE
test: COST-7485 verify label gate fix for non-koku components

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ _Note:_ Delete OpenShift resources with the following command:
 ```
 oc process --param-file openshift/parameters.properties  -f openshift/ |  oc delete -f -
 ```
+# COST-7485 test


### PR DESCRIPTION
## Purpose

This is a **test PR** to verify that [koku-test-container#88](https://github.com/project-koku/koku-test-container/pull/88) correctly fixed the label gate for non-koku repos.

Before the fix, this PR would fail CI with:
```
[ERROR] No labels found on PR #N. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.
```

This PR intentionally has **no smoke labels** to confirm the CI now passes without them.

**Can be closed/deleted after CI passes.**

Related: [COST-7485](https://issues.redhat.com/browse/COST-7485)

Made with [Cursor](https://cursor.com)